### PR TITLE
Configure the .semanticGroup accessibilityContainerType to the tab bar container view

### DIFF
--- a/Candybar/ViewController.swift
+++ b/Candybar/ViewController.swift
@@ -31,6 +31,9 @@ class ViewController: UIViewController {
         [camera, bookmarks, compose, rewind].forEach(candybar.addArrangedSubview)
         candybar.accessibilityTraits = .tabBar
         candybar.isAccessibilityElement = false
+
+        candybar.accessibilityContainerType = .semanticGroup
+        candybar.accessibilityLabel = "Tab Bar"
     }
 
 


### PR DESCRIPTION
Set the accessibility container type of the container view for b bar as a semantic group. Then, configure the "tab bar" accessibility label to it too so when the focus goes from outside the container to an element in the container, it VoiceOver announces "Tab bar" before announcing the selected element.